### PR TITLE
Fixed broken links in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Pure Python dependencies for `Playdoh <http://github.com/fwenzel/playdoh>`_.
+Pure Python dependencies for `Playdoh <https://github.com/mozilla/playdoh>`_.
 
 For more information, take a look at the `packaging documentation
-<http://mozilla.github.com/playdoh/packaging/>`_.
+<http://mozilla.github.com/playdoh/packages/>`_.


### PR DESCRIPTION
Playdoh and Playdoh packaging docs links were old and broken.
