### PR TITLE
Update to Django 1.4.5

### DIFF
--- a/lib/python/django/__init__.py
+++ b/lib/python/django/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 4, 4, 'final', 0)
+VERSION = (1, 4, 5, 'final', 0)
 
 def get_version(version=None):
     """Derives a PEP386-compliant version number from VERSION."""

--- a/lib/python/django/conf/project_template/project_name/settings.py
+++ b/lib/python/django/conf/project_template/project_name/settings.py
@@ -21,7 +21,7 @@ DATABASES = {
 }
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
-# See https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/#allowed-hosts
+# See https://docs.djangoproject.com/en/1.4/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = []
 
 # Local time zone for this installation. Choices can be found here:


### PR DESCRIPTION
This is pretty much a no-op for us since there weren't any changes
between 1.4.4 and 1.4.5 that affects playdoh.

Super quick r?
